### PR TITLE
:sparkles: SVGButton 컴포넌트 추가

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,7 @@
     "plugin:react/jsx-runtime"
   ],
   "rules": {
-    "no-console": "error",
+    "no-console": 1,
     "import/order": [
       "error",
       {
@@ -37,6 +37,7 @@
       }
     ],
     "@typescript-eslint/explicit-module-boundary-types": "off",
-    "react/require-default-props": [0]
+    "react/require-default-props": [0],
+    "react/button-has-type": [0]
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "private": true,
   "dependencies": {
     "classnames": "^2.3.1",
+    "components": "link:./src/components",
     "modern-css-reset": "^1.4.0",
     "pages": "link:./src/pages",
     "react": "^17.0.2",

--- a/src/components/SVGButton/SVGButton.module.scss
+++ b/src/components/SVGButton/SVGButton.module.scss
@@ -1,0 +1,6 @@
+.svg-button {
+  display: flex;
+  padding: 0;
+  background-color: transparent;
+  border: none;
+}

--- a/src/components/SVGButton/index.tsx
+++ b/src/components/SVGButton/index.tsx
@@ -1,0 +1,20 @@
+import styles from './SVGButton.module.scss';
+
+import cx from 'classnames';
+
+interface SVGButtonProps {
+  className?: string;
+  icon: React.ReactElement<
+    React.FunctionComponent<
+      React.SVGProps<SVGSVGElement> & {
+        title?: string | undefined;
+      }
+    >
+  >;
+}
+
+const SVGButton = ({ className, icon }: SVGButtonProps) => {
+  return <button className={cx(styles['svg-button'], className)}>{icon}</button>;
+};
+
+export default SVGButton;

--- a/src/pages/MonthlyDiaryPage/components/DiaryCard/index.tsx
+++ b/src/pages/MonthlyDiaryPage/components/DiaryCard/index.tsx
@@ -5,6 +5,7 @@ import DUMMY_DOG_THUMBNAIL from 'assets/img_dummy_dog.png';
 import style from './DiaryCard.module.scss';
 
 import cx from 'classnames';
+import SVGButton from 'components/SVGButton';
 
 interface DiaryCardProps {
   classNames?: string;
@@ -14,9 +15,9 @@ const DiaryCard = ({ classNames }: DiaryCardProps) => {
   return (
     <div className={cx(style['diary-card'], classNames)}>
       <header className={style['diary-card__header']}>
-        <GreenDotIcon />
+        <SVGButton icon={<GreenDotIcon />} />
         <p className={style['diary-card__date']}>14. SAT</p>
-        <MoreHorizontalIcon className={style['diary-card__more']} />
+        <SVGButton icon={<MoreHorizontalIcon />} className={style['diary-card__more']} />
       </header>
       <div className={style['diary-card__article']}>
         <div className={style['diary-card__summary']}>

--- a/src/pages/MonthlyDiaryPage/components/FixedHeader/index.tsx
+++ b/src/pages/MonthlyDiaryPage/components/FixedHeader/index.tsx
@@ -3,17 +3,19 @@ import { ReactComponent as CaretDownIcon } from 'assets/ic_caret_down.svg';
 
 import style from './FixedHeader.module.scss';
 
+import SVGButton from 'components/SVGButton';
+
 const FixedHeader = () => {
   return (
     <header className={style['fixed-header']}>
       <p className={style['fixed-header__logo']}>로고</p>
       <div className={style['fixed-header__month-picker']}>
         <p className={style['fixed-header__month']}>10월</p>
-        <CaretDownIcon className={style['fixed-header__caret-icon']} />
+        <SVGButton icon={<CaretDownIcon />} className={style['fixed-header__caret-icon']} />
       </div>
 
       <div className={style['fixed-header__calendar']}>
-        <CalendarIcon className={style['fixed-header__calendar-icon']} />
+        <SVGButton icon={<CalendarIcon />} className={style['fixed-header__calendar-icon']} />
       </div>
     </header>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4833,6 +4833,12 @@ __metadata:
   languageName: node
   linkType: hard
 
+"components@link:./src/components::locator=eclass-web%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "components@link:./src/components::locator=eclass-web%40workspace%3A."
+  languageName: node
+  linkType: soft
+
 "compose-function@npm:3.0.3":
   version: 3.0.3
   resolution: "compose-function@npm:3.0.3"
@@ -5972,6 +5978,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^4.31.2
     "@typescript-eslint/parser": ^4.31.2
     classnames: ^2.3.1
+    components: "link:./src/components"
     eslint: ^7.32.0
     eslint-config-airbnb: ^18.2.1
     eslint-config-airbnb-typescript: ^14.0.0
@@ -10005,8 +10012,8 @@ fsevents@^1.2.7:
   linkType: hard
 
 "lint-staged@npm:^11.1.2":
-  version: 11.1.2
-  resolution: "lint-staged@npm:11.1.2"
+  version: 11.1.4
+  resolution: "lint-staged@npm:11.1.4"
   dependencies:
     chalk: ^4.1.1
     cli-truncate: ^2.1.0
@@ -10024,7 +10031,7 @@ fsevents@^1.2.7:
     stringify-object: ^3.3.0
   bin:
     lint-staged: bin/lint-staged.js
-  checksum: 0050d1836dda879c58561fa4efd100f5cd14fcbf8ee3fdeab7e89ec4219c019543bb5bf2442f760557ebe4bb8b7bfc56a9c98b9384acecfe0f8553f091723e36
+  checksum: aa2a54678f639f90a08d059f510274371d2fceb4866da35dbd2d84205027ddca30114702c78507ee34c12d850d640a20434b508df1e0e8827a1276eb5d0939b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
SVG를 주입받아 버튼 엘리먼트로 내려주는 SVGButton 컴포넌트를 추가했습니당

사용법

```typescript
import { ReactComponent as GreenDotIcon } from 'assets/ic_green_dot.svg';

...
<SVGButton icon={<GreenDotIcon />} /> 
```