### PR TITLE
🔧 sass @use 생략 가능하게끔 craco 적용

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,0 +1,25 @@
+module.exports = {
+  style: {
+    sass: {
+      loaderOptions: (sassLoaderOptions, { paths }) => {
+        return {
+          ...sassLoaderOptions,
+          additionalData: `
+            @use "sass:color";
+            @use "sass:list";
+            @use "sass:map";
+            @use "sass:math";
+            @use "sass:meta";
+            @use "sass:selector";
+            @use "sass:string";
+            @use "utils" as *;
+            @use "variables" as *;
+          `,
+          sassOptions: {
+            includePaths: [paths.appSrc + '/styles']
+          }
+        };
+      },
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "private": true,
   "dependencies": {
+    "@craco/craco": "^6.3.0",
     "classnames": "^2.3.1",
     "components": "link:./src/components",
     "modern-css-reset": "^1.4.0",
@@ -49,8 +50,8 @@
     "typescript": "^4.4.3"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "craco start",
+    "build": "craco build",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint --fix --ext .js,.jsx,.ts,.tsx",
     "lint:style": "stylelint '**/*.{scss,css}'",

--- a/src/pages/DiaryDetailPage/DiaryDetailPage.module.scss
+++ b/src/pages/DiaryDetailPage/DiaryDetailPage.module.scss
@@ -1,5 +1,3 @@
-@use 'styles/utils' as *;
-
 .diary-detail-page {
   &__footer {
     position: fixed;

--- a/src/pages/DiaryDetailPage/components/DiaryDescriptionHeader/DiaryDescriptionHeader.module.scss
+++ b/src/pages/DiaryDetailPage/components/DiaryDescriptionHeader/DiaryDescriptionHeader.module.scss
@@ -1,5 +1,3 @@
-@use 'styles/utils' as *;
-
 .diary-description-header {
   display: flex;
 

--- a/src/pages/MonthlyDiaryPage/MonthlyDiaryPage.module.scss
+++ b/src/pages/MonthlyDiaryPage/MonthlyDiaryPage.module.scss
@@ -1,5 +1,3 @@
-@use 'styles/variables' as *;
-
 .monthly-diary {
   $self: &;
 

--- a/src/pages/MonthlyDiaryPage/components/DiaryCard/DiaryCard.module.scss
+++ b/src/pages/MonthlyDiaryPage/components/DiaryCard/DiaryCard.module.scss
@@ -1,5 +1,3 @@
-@use 'styles/utils' as *;
-
 .diary-card {
   $self: &;
 

--- a/src/pages/MonthlyDiaryPage/components/FixedHeader/FixedHeader.module.scss
+++ b/src/pages/MonthlyDiaryPage/components/FixedHeader/FixedHeader.module.scss
@@ -1,6 +1,3 @@
-@use 'styles/variables' as *;
-@use 'styles/utils' as *;
-
 .fixed-header {
   @include flexSpaceBetween(row);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1666,6 +1666,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@craco/craco@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "@craco/craco@npm:6.3.0"
+  dependencies:
+    cross-spawn: ^7.0.0
+    lodash: ^4.17.15
+    semver: ^7.3.2
+    webpack-merge: ^4.2.2
+  peerDependencies:
+    react-scripts: ^4.0.0
+  bin:
+    craco: bin/craco.js
+  checksum: 0cc2de18e8bd9f0b79134850691cdc93037ea0aa4ec9d087ccf29e5146e3cba95256535653cdb32103cbd24d86ad2f75932f32d852445631404f5e0989c1cd2e
+  languageName: node
+  linkType: hard
+
 "@csstools/convert-colors@npm:^1.4.0":
   version: 1.4.0
   resolution: "@csstools/convert-colors@npm:1.4.0"
@@ -5978,6 +5994,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "eclass-web@workspace:."
   dependencies:
+    "@craco/craco": ^6.3.0
     "@types/eslint": ^7.28.0
     "@types/node": ^12.0.0
     "@types/react": ^17.0.0
@@ -16926,6 +16943,15 @@ typescript@^4.4.3:
   peerDependencies:
     webpack: 2 || 3 || 4
   checksum: ed1387774031a59bc1bd5f79150e7a49dcf5048a6d5e9652672637bed7f93df6220cbd88b2e371e7c8c8e7640b3a8ed6895f771c6b05a8bb90b721f82001ac25
+  languageName: node
+  linkType: hard
+
+"webpack-merge@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "webpack-merge@npm:4.2.2"
+  dependencies:
+    lodash: ^4.17.15
+  checksum: ce58bc8ab53a3dd5d9a0df65684571349eef53372bf8f224521072110485391335b26ab097c5f07829b88d0c146056944149566e5a953f05997b0fe2cbaf8dd6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- scss 파일에서 @use를 사용하는 부분을 sass-loader의 additionalData 프로퍼티를 이용하여 자동으로 추가해주게끔 설정하였습니다.
- craco를 설치하여 package.json의 start, build 스크립트를 수정해주어야 하기 때문에 논의 후에 반영할지 말지 결정하면 좋을 것 같아요!