### PR TITLE
:lipstick: px단위를 rem으로 일괄변경

### DIFF
--- a/src/pages/DiaryDetailPage/DiaryDetailPage.module.scss
+++ b/src/pages/DiaryDetailPage/DiaryDetailPage.module.scss
@@ -10,8 +10,8 @@
     @include flexSpaceBetween;
 
     width: 100%;
-    height: 56px;
-    padding: 0 24px;
+    height: 5.6rem;
+    padding: 0 2.4rem;
     box-shadow: 0 1px 7px rgba(0, 0, 0, 0.12);
   }
 }

--- a/src/pages/DiaryDetailPage/components/Carousel/Carousel.module.scss
+++ b/src/pages/DiaryDetailPage/components/Carousel/Carousel.module.scss
@@ -27,7 +27,7 @@
     width: 76px;
     padding: 0;
     color: #fff;
-    font-size: 12px;
+    font-size: 1.2rem;
     line-height: 26px;
     background: rgba(5, 5, 5, 0.15);
     border: none;

--- a/src/pages/DiaryDetailPage/components/Carousel/Carousel.module.scss
+++ b/src/pages/DiaryDetailPage/components/Carousel/Carousel.module.scss
@@ -1,10 +1,10 @@
 .carousel {
-  height: calc(423px + 19px + 10px);
+  height: calc(42.3rem + 1.9rem + 1rem);
 
   &__item {
     display: block;
     width: 100%;
-    height: 423px;
+    height: 42.3rem;
   }
 
   :global(.swiper-pagination-bullets) {
@@ -21,17 +21,17 @@
 
   button {
     position: absolute;
-    right: 20px;
-    bottom: calc(19px + 16px + 10px);
+    right: 2rem;
+    bottom: calc(1.9rem + 1.6rem + 1rem);
     z-index: 1;
-    width: 76px;
+    width: 7.6rem;
     padding: 0;
     color: #fff;
     font-size: 1.2rem;
-    line-height: 26px;
+    line-height: 2.6;
     background: rgba(5, 5, 5, 0.15);
     border: none;
-    border-radius: 40px;
+    border-radius: 4rem;
     opacity: 0.8;
   }
 }

--- a/src/pages/DiaryDetailPage/components/DiaryDescription/DiaryDescription.module.scss
+++ b/src/pages/DiaryDetailPage/components/DiaryDescription/DiaryDescription.module.scss
@@ -1,6 +1,6 @@
 .diary-description {
   margin-top: 1.6rem;
-  padding: 0 24px;
+  padding: 0 2.4rem;
 
   &__content {
     margin-top: 1.6rem;

--- a/src/pages/DiaryDetailPage/components/DiaryDescription/DiaryDescription.module.scss
+++ b/src/pages/DiaryDetailPage/components/DiaryDescription/DiaryDescription.module.scss
@@ -1,9 +1,9 @@
 .diary-description {
-  margin-top: 1rem;
+  margin-top: 1.6rem;
   padding: 0 24px;
 
   &__content {
-    margin-top: 1rem;
+    margin-top: 1.6rem;
     line-height: 1.5;
   }
 }

--- a/src/pages/DiaryDetailPage/components/DiaryDescriptionHeader/DiaryDescriptionHeader.module.scss
+++ b/src/pages/DiaryDetailPage/components/DiaryDescriptionHeader/DiaryDescriptionHeader.module.scss
@@ -11,13 +11,13 @@
 
   &__info {
     color: #a09d96;
-    font-size: 12px;
+    font-size: 1.2rem;
     line-height: 21px;
   }
 
   &__title {
     color: #484747;
-    font-size: 16px;
+    font-size: 1.6rem;
   }
 
   &__author {

--- a/src/pages/DiaryDetailPage/components/DiaryDescriptionHeader/DiaryDescriptionHeader.module.scss
+++ b/src/pages/DiaryDetailPage/components/DiaryDescriptionHeader/DiaryDescriptionHeader.module.scss
@@ -12,7 +12,7 @@
   &__info {
     color: #a09d96;
     font-size: 1.2rem;
-    line-height: 21px;
+    line-height: 2.1;
   }
 
   &__title {

--- a/src/pages/MonthlyDiaryPage/MonthlyDiaryPage.module.scss
+++ b/src/pages/MonthlyDiaryPage/MonthlyDiaryPage.module.scss
@@ -3,12 +3,12 @@
 .monthly-diary {
   $self: &;
 
-  margin: calc($header-height-with-safe-area + 16px) 0 55px;
-  padding: 0 14px;
+  margin: calc($header-height-with-safe-area + 1.6rem) 0 5.5rem;
+  padding: 0 1.4rem;
 
   &__list {
     #{$self}__item {
-      margin-top: 14px;
+      margin-top: 1.4rem;
     }
   }
 }

--- a/src/pages/MonthlyDiaryPage/components/DiaryCard/DiaryCard.module.scss
+++ b/src/pages/MonthlyDiaryPage/components/DiaryCard/DiaryCard.module.scss
@@ -15,7 +15,7 @@
       margin-left: 8px;
       color: #356859;
       font-weight: 800;
-      font-size: 18px;
+      font-size: 1.8rem;
       line-height: 21px;
     }
 
@@ -37,13 +37,13 @@
 
       color: #484747;
       font-weight: 500;
-      font-size: 14px;
+      font-size: 1.4rem;
     }
 
     #{$self}__extra-content {
       color: #a09d96;
       font-weight: bold;
-      font-size: 12px;
+      font-size: 1.2rem;
     }
   }
 

--- a/src/pages/MonthlyDiaryPage/components/DiaryCard/DiaryCard.module.scss
+++ b/src/pages/MonthlyDiaryPage/components/DiaryCard/DiaryCard.module.scss
@@ -3,9 +3,9 @@
 .diary-card {
   $self: &;
 
-  padding: 20px;
+  padding: 2rem;
   background: white;
-  border-radius: 15px;
+  border-radius: 1.5rem;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
 
   &__header {
@@ -16,7 +16,7 @@
       color: #356859;
       font-weight: 800;
       font-size: 1.8rem;
-      line-height: 21px;
+      line-height: 2.1;
     }
 
     #{$self}__more {
@@ -26,7 +26,7 @@
 
   &__article {
     display: flex;
-    margin-top: 20px;
+    margin-top: 2rem;
   }
 
   &__summary {
@@ -48,7 +48,7 @@
   }
 
   &__thumbnail {
-    margin-left: 16px;
-    border-radius: 16px;
+    margin-left: 1.6rem;
+    border-radius: 1.6rem;
   }
 }

--- a/src/pages/MonthlyDiaryPage/components/FixedHeader/FixedHeader.module.scss
+++ b/src/pages/MonthlyDiaryPage/components/FixedHeader/FixedHeader.module.scss
@@ -12,7 +12,7 @@
   align-items: center;
   width: 100%;
   height: $header-height-with-safe-area;
-  padding: $safe-area-inset-top 20px 0;
+  padding: $safe-area-inset-top 2rem 0;
   background-color: inherit;
 
   &__logo {
@@ -27,7 +27,7 @@
       flex: 1;
       font-weight: bold;
       font-size: 1.6rem;
-      line-height: 26px;
+      line-height: 2.6;
       text-align: center;
     }
 

--- a/src/pages/MonthlyDiaryPage/components/FixedHeader/FixedHeader.module.scss
+++ b/src/pages/MonthlyDiaryPage/components/FixedHeader/FixedHeader.module.scss
@@ -26,7 +26,7 @@
     #{$self}__month {
       flex: 1;
       font-weight: bold;
-      font-size: 16px;
+      font-size: 1.6rem;
       line-height: 26px;
       text-align: center;
     }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -10,6 +10,11 @@ $background-color: #fdf7ea;
   -webkit-touch-callout: none;
 }
 
+html {
+  /* 1rem = 10px */
+  font-size: 62.5%;
+}
+
 body {
   min-height: 100vh;
   min-height: -webkit-fill-available;

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,3 +1,3 @@
-$header-height: 52px;
-$safe-area-inset-top: env(safe-area-inset-top, 20px);
+$header-height: 5.2rem;
+$safe-area-inset-top: env(safe-area-inset-top, 2rem);
 $header-height-with-safe-area: calc($header-height + $safe-area-inset-top);


### PR DESCRIPTION
## 변경점

전역에서 사용되고 있는 px단위를 rem으로 사용하기 위해 글로벌 폰트 사이즈를 10px로 변경하고, 일괄적으로 변경하였습니다.

```css
html {
  /* 1rem = 10px */
  font-size: 62.5%;
}



.class {
  */ 사용 예시 (피그마에 있는 px단위에서 10을 나눠서 사용하면 됩니다) */
  font-size: 1.6rem;
}

```

## 논의가 필요한 부분
* font-size외에 다른 값들은 px로 사용할지, 동일하게 rem을 사용할지
* 만약 rem을 사용한다면 10px미만의 값들은 고정값 (px)을 사용할지 rem을 사용할지