### PR TITLE
:sparkles: Toast 컴포넌트 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "classnames": "^2.3.1",
     "components": "link:./src/components",
+    "hooks": "link:./src/hooks",
     "modern-css-reset": "^1.4.0",
     "pages": "link:./src/pages",
     "react": "^17.0.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,29 @@
+import Toast, { toastTextAtom } from 'components/Toast';
 import { lazy, Suspense } from 'react';
 import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 
 const LazyMonthlyDiaryPage = lazy(() => import(/* webpackChunkName: "MonthlyDiaryPage" */ 'pages/MonthlyDiaryPage'));
 const LazyDiaryDetailPage = lazy(() => import(/* webpackChunkName: "DiaryDetailPage" */ 'pages/DiaryDetailPage'));
 
 const App = () => {
+  const toastText = useRecoilValue(toastTextAtom);
+
   return (
-    <Suspense fallback={null}>
-      <BrowserRouter>
-        <Switch>
-          <Route exact path="/">
-            <Redirect to="/monthly-diary" />
-          </Route>
-          <Route exact path="/monthly-diary" component={LazyMonthlyDiaryPage} />
-          <Route exact path="/diary-detail" component={LazyDiaryDetailPage} />
-        </Switch>
-      </BrowserRouter>
-    </Suspense>
+    <>
+      <Suspense fallback={null}>
+        <BrowserRouter>
+          <Switch>
+            <Route exact path="/">
+              <Redirect to="/monthly-diary" />
+            </Route>
+            <Route exact path="/monthly-diary" component={LazyMonthlyDiaryPage} />
+            <Route exact path="/diary-detail" component={LazyDiaryDetailPage} />
+          </Switch>
+        </BrowserRouter>
+      </Suspense>
+      {toastText && <Toast />}
+    </>
   );
 };
 

--- a/src/components/Toast/Toast.module.scss
+++ b/src/components/Toast/Toast.module.scss
@@ -1,0 +1,21 @@
+@use 'styles/typography' as *;
+@use 'styles/colors' as *;
+@use 'styles/utils' as *;
+
+.toast-container {
+  position: fixed;
+
+  bottom: 2.8rem;
+  left: 50%;
+  z-index: z-index(toast);
+  transform: translateX(-50%);
+
+  .toast {
+    @include typography(header3);
+
+    padding: 1rem 3rem;
+    color: white;
+    background-color: rgba(0, 0, 0, 0.5);
+    border-radius: 3.9rem;
+  }
+}

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -1,0 +1,23 @@
+import styles from './Toast.module.scss';
+
+import classNames from 'classnames/bind';
+import { atom, useRecoilValue } from 'recoil';
+
+const cx = classNames.bind(styles);
+
+export const toastTextAtom = atom<string | undefined>({
+  key: 'toastTextAtom',
+  default: undefined,
+});
+
+const Toast = () => {
+  const toastText = useRecoilValue(toastTextAtom);
+
+  return (
+    <div className={cx('toast-container')}>
+      <div className={cx('toast')}>{toastText}</div>
+    </div>
+  );
+};
+
+export default Toast;

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,26 @@
+import { toastTextAtom } from 'components/Toast';
+import { useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
+
+interface UseToastParams {
+  conditions: boolean[];
+  message: string;
+  dependencies: unknown[];
+}
+
+const TOAST_DURATION_TIME = 2000;
+
+export const useToast = ({ conditions, message, dependencies }: UseToastParams): void => {
+  const setToastText = useSetRecoilState(toastTextAtom);
+
+  useEffect(() => {
+    if (conditions.every((condition) => condition)) {
+      setToastText(message);
+
+      setTimeout(() => {
+        setToastText(undefined);
+      }, TOAST_DURATION_TIME);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, dependencies);
+};

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -2,15 +2,16 @@ import { toastTextAtom } from 'components/Toast';
 import { useEffect } from 'react';
 import { useSetRecoilState } from 'recoil';
 
+type DependencyArray = unknown[];
+
 interface UseToastParams {
   conditions: boolean[];
   message: string;
-  dependencies: unknown[];
 }
 
 const TOAST_DURATION_TIME = 2000;
 
-export const useToast = ({ conditions, message, dependencies }: UseToastParams): void => {
+export const useToast = ({ conditions, message }: UseToastParams, dependencies?: DependencyArray): void => {
   const setToastText = useSetRecoilState(toastTextAtom);
 
   useEffect(() => {

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -14,13 +14,16 @@ export const useToast = ({ conditions, message, dependencies }: UseToastParams):
   const setToastText = useSetRecoilState(toastTextAtom);
 
   useEffect(() => {
-    if (conditions.every((condition) => condition)) {
-      setToastText(message);
-
-      setTimeout(() => {
-        setToastText(undefined);
-      }, TOAST_DURATION_TIME);
+    if (!conditions.every((condition) => condition)) {
+      return;
     }
+
+    setToastText(message);
+
+    setTimeout(() => {
+      setToastText(undefined);
+    }, TOAST_DURATION_TIME);
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, dependencies);
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,12 +2,15 @@ import App from './App';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { RecoilRoot } from 'recoil';
 
 import 'styles/index.scss';
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <RecoilRoot>
+      <App />
+    </RecoilRoot>
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/src/styles/utils.scss
+++ b/src/styles/utils.scss
@@ -1,4 +1,5 @@
 $z-index: (
+  toast: 102,
   modal: 101,
   fixed-header: 100,
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -6007,6 +6007,7 @@ __metadata:
     eslint-plugin-prettier: ^4.0.0
     eslint-plugin-react: ^7.26.0
     eslint-plugin-react-hooks: ^4.2.0
+    hooks: "link:./src/hooks"
     husky: ^7.0.0
     lint-staged: ^11.1.2
     modern-css-reset: ^1.4.0
@@ -7960,6 +7961,12 @@ fsevents@^1.2.7:
   checksum: b1538270429b13901ee586aa44f4cc3ecd8831c061d06cb8322e50ea17b3f5ce4d0e2e66394761e6c8e152cd8c34fb3b4b690116c6ce2bd45b18c746516cb9e8
   languageName: node
   linkType: hard
+
+"hooks@link:./src/hooks::locator=eclass-web%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "hooks@link:./src/hooks::locator=eclass-web%40workspace%3A."
+  languageName: node
+  linkType: soft
 
 "hoopy@npm:^0.1.4":
   version: 0.1.4


### PR DESCRIPTION
<img width="350" alt="스크린샷 2021-11-11 오후 9 32 43" src="https://user-images.githubusercontent.com/38802280/141298837-5a7d5c67-493d-4348-9c49-6b4502217a28.png">

Toast 컴포넌트를 추가하였습니다. 
Toast는 2초뒤에 사라지며, 사용방법은 다음과 같습니다.

```typescript
// conditions: 해당 배열의 값이 모두 true일때
// dependencies: react dependency array와 동일 (해당 값이 변할 때)
// message: toast 메시지

useToast({
    conditions: [],
    dependencies: [],
    message: '일기를 삭제 했어요',
  });


```